### PR TITLE
Update TX Payload Reference

### DIFF
--- a/tips/TIP-0024/tip-0024.md
+++ b/tips/TIP-0024/tip-0024.md
@@ -136,10 +136,10 @@ The following criteria defines whether the message passes the syntactical valida
 While messages without a payload, i.e. `Payload Length` set to zero, are valid, such messages do not contain any information. As such, messages usually contain a payload. The detailed specification of each payload type is out of scope of this TIP. The following table lists all currently specified payloads that can be part of a message and links to their specification:
 
 | Payload Name | Type Value | TIP                                     |
-| ------------ | ---------- | --------------------------------------- |
-| Transaction  | 0          | [TIP-7](../TIP-0007/tip-0007.md)        |
+|--------------|------------|-----------------------------------------|
 | Milestone    | 1          | [TIP-8](../TIP-0008/tip-0008.md)        |
 | Tagged Data  | 5          | [draft TIP-23](../TIP-0023/tip-0023.md) |
+| Transaction  | 6          | [draft TIP-20](../TIP-0020/tip-0020.md) |
 
 ## Example
 


### PR DESCRIPTION
Tx payload type bumped in TIP-20 (https://github.com/iotaledger/tips/pull/40/commits/15cc7b365a39cd12cac0450b61618e90f14a6072) as to not reuse any types from Chrysalis.